### PR TITLE
Always run post cache action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [_Unreleased_](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.1...main)
 
-- Always run post action step to ensure even failed builds can cache
+- Add input to allow post action step to run even when prior steps fail
 
 ## [v1.0.1](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0...v1.0.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [_Unreleased_](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.1...main)
 
-None
+- Always run post action step to ensure even failed builds can cache
 
 ## [v1.0.1](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0...v1.0.1)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ uses: freckle/stack-cache-action@main
 - `stack-yaml`: Path to your `stack.yaml` file
 - `working-directory`: Useful in monorepositories
 - `prefix`: A prefix to include on keys; useful for cache busting or versioning
+- `always-store`: (Optional: defaults `true`) If true, will execute the post-run cache action whether or not prior steps are successful
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,6 @@ runs:
   using: "node12"
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
-  post-if: "success()"
 inputs:
   stack-yaml:
     description: "Path to stack.yaml"

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ runs:
   using: "node12"
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
+  post-if: "success() || inputs.always-store == 'true'"
 inputs:
   stack-yaml:
     description: "Path to stack.yaml"
@@ -18,6 +19,10 @@ inputs:
     description: "A prefix to include on keys; useful for cache busting or versioning"
     required: false
     default: ""
+  always-store:
+    description: "If true, will execute the post-run cache action whether or not prior steps are successful"
+    required: false
+    default: "true"
 outputs:
   cache-hit:
     description: "A boolean value to indicate an exact match was found for the primary key"


### PR DESCRIPTION
**Why?**

I'm mainly doing this to decrease cycle time as I'm starting to use this in our
megarepo. The scenario is, I'm trying to convert our backend test over, they're
failing but dependencies are not being cached. Dependency install take something
like 50 minutes.

It's my understanding that failed builds (e.g. failing on test run) should still
have their dependencies cached.