### PR TITLE
Revert "Always run post cache action (#38)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [_Unreleased_](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.1...main)
 
-- Add input to allow post action step to run even when prior steps fail
+None
 
 ## [v1.0.1](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0...v1.0.1)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ uses: freckle/stack-cache-action@main
 - `stack-yaml`: Path to your `stack.yaml` file
 - `working-directory`: Useful in monorepositories
 - `prefix`: A prefix to include on keys; useful for cache busting or versioning
-- `always-store`: (Optional: defaults `true`) If true, will execute the post-run cache action whether or not prior steps are successful
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "node12"
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
-  post-if: "success() || inputs.always-store == 'true'"
+  post-if: "success()"
 inputs:
   stack-yaml:
     description: "Path to stack.yaml"
@@ -19,10 +19,6 @@ inputs:
     description: "A prefix to include on keys; useful for cache busting or versioning"
     required: false
     default: ""
-  always-store:
-    description: "If true, will execute the post-run cache action whether or not prior steps are successful"
-    required: false
-    default: "true"
 outputs:
   cache-hit:
     description: "A boolean value to indicate an exact match was found for the primary key"


### PR DESCRIPTION
This reverts commit 6e75d27d680a230abdc6f50fc541d3e213ef7e77.

This didn't work. You can see my various failures to get it to work in
this PR: https://github.com/freckle/stack-cache-action/pull/39