### PR TITLE
Always store cache regardless of build status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [_Unreleased_](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.1...main)
 
-None
+- Always store cache regardless of build status
 
 ## [v1.0.1](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0...v1.0.1)
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,6 @@ runs:
   using: "node12"
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
-  post-if: "success()"
 inputs:
   stack-yaml:
     description: "Path to stack.yaml"


### PR DESCRIPTION
We can merge this or not. I'm just going to simplify things and reference it
directly either way to speed up my cycle time.