### PR TITLE
Fix #61: Link to blog post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ uses: freckle/stack-cache-action@main
 
 - `cache-hit`: indicates a full cache hit on the primary key
 
+## Further Reading
+
+See https://tech.freckle.com/2021/05/18/haskell-on-actions/ for a short tutorial.
+
 ## Acknowledgements
 
 The idea and initial repository skeleton was taken from [gha-yarn-cache][].


### PR DESCRIPTION
This is a minimal fix for #61.

Of course, it would be great to link to real-world uses of this action.  
But I don't know of these, so I delegate this to an expert.