### PR TITLE
Fix for windows, missing .lock, and forgotten .stack-work

### DIFF
--- a/src/stack-cache.js
+++ b/src/stack-cache.js
@@ -1,5 +1,6 @@
 const os = require("os");
 const path = require("path");
+const process = require("process");
 const utils = require("./utils.js");
 const inputs = require("./inputs.js");
 
@@ -17,6 +18,10 @@ async function getLockOrSelf(path) {
 
 async function getManifestPaths() {
   return utils.globAll(MANIFEST_PATTERNS);
+}
+
+function unique(items) {
+  return Array.from(new Set(items));
 }
 
 module.exports = {
@@ -38,11 +43,18 @@ module.exports = {
   },
 
   getPaths: async () => {
+    // All of these need to be cached:
+    //
+    // - ~/.stack
+    // - ./.stack-work
+    // - ./{package}/.stack-work
+    //
     const manifestPaths = await getManifestPaths();
     const stackHome = path.join(os.homedir(), ".stack");
+    const stackWork = path.join(process.cwd(), ".stack-work");
     const stackWorks = manifestPaths.map(p =>
       path.join(path.dirname(p), ".stack-work")
     );
-    return [stackHome].concat(stackWorks);
+    return unique([stackHome, stackWork].concat(stackWorks));
   },
 };

--- a/src/stack-cache.js
+++ b/src/stack-cache.js
@@ -4,6 +4,16 @@ const inputs = require("./inputs.js");
 
 const MANIFEST_PATTERNS = ["**/*.cabal", "**/package.yaml"];
 
+async function getLockOrSelf(path) {
+  const paths = await utils.globAll([`${path}.lock`, path]);
+
+  if (paths === null || paths === undefined || paths.length === 0) {
+    throw new Error(`Neither ${path}.lock nor ${path} exist`);
+  }
+
+  return paths[0];
+}
+
 async function getManifestPaths() {
   return utils.globAll(MANIFEST_PATTERNS);
 }
@@ -12,7 +22,7 @@ module.exports = {
   getCacheKeys: async stackYaml => {
     const prefix = inputs.getPrefix();
     const os = await utils.uname();
-    const lockPath = `${stackYaml}.lock`;
+    const lockPath = await getLockOrSelf(stackYaml);
     const lockHash = await utils.hashFiles([lockPath]);
     const manifestPaths = await getManifestPaths();
     const manifestHash = await utils.hashFiles(manifestPaths);

--- a/src/stack-cache.js
+++ b/src/stack-cache.js
@@ -6,11 +6,11 @@ const inputs = require("./inputs.js");
 
 const MANIFEST_PATTERNS = ["**/*.cabal", "**/package.yaml"];
 
-async function getLockOrSelf(path) {
-  const paths = await utils.globAll([`${path}.lock`, path]);
+async function getLockOrSelf(p) {
+  const paths = await utils.globAll([`${p}.lock`, p]);
 
   if (paths === null || paths === undefined || paths.length === 0) {
-    throw new Error(`Neither ${path}.lock nor ${path} exist`);
+    throw new Error(`Neither ${p}.lock nor ${p} exist`);
   }
 
   return paths[0];
@@ -27,7 +27,7 @@ function unique(items) {
 module.exports = {
   getCacheKeys: async stackYaml => {
     const prefix = inputs.getPrefix();
-    const os = await utils.uname();
+    const uname = await utils.uname();
     const lockPath = await getLockOrSelf(stackYaml);
     const lockHash = await utils.hashFiles([lockPath]);
     const manifestPaths = await getManifestPaths();
@@ -36,9 +36,9 @@ module.exports = {
     const sourceHash = await utils.hashFiles(gitLsFiles.split("\n"));
 
     return [
-      `${prefix}${os}-${lockHash}-${manifestHash}-${sourceHash}`,
-      `${prefix}${os}-${lockHash}-${manifestHash}-`,
-      `${prefix}${os}-${lockHash}-`,
+      `${prefix}${uname}-${lockHash}-${manifestHash}-${sourceHash}`,
+      `${prefix}${uname}-${lockHash}-${manifestHash}-`,
+      `${prefix}${uname}-${lockHash}-`,
     ];
   },
 

--- a/src/stack-cache.js
+++ b/src/stack-cache.js
@@ -1,3 +1,4 @@
+const os = require("os");
 const path = require("path");
 const utils = require("./utils.js");
 const inputs = require("./inputs.js");
@@ -38,7 +39,7 @@ module.exports = {
 
   getPaths: async () => {
     const manifestPaths = await getManifestPaths();
-    const stackHome = path.join(process.env.HOME, ".stack");
+    const stackHome = path.join(os.homedir(), ".stack");
     const stackWorks = manifestPaths.map(p =>
       path.join(path.dirname(p), ".stack-work")
     );

--- a/src/stack-cache.test.js
+++ b/src/stack-cache.test.js
@@ -80,8 +80,8 @@ describe("stackCache", () => {
         const cachePaths = await stackCache.getPaths();
         expect(cachePaths).toStrictEqual([
           path.join(home, ".stack"),
-          path.join(cwd, "package", ".stack-work"),
           path.join(cwd, ".stack-work"),
+          path.join(cwd, "package", ".stack-work"),
         ]);
       });
     });

--- a/src/stack-cache.test.js
+++ b/src/stack-cache.test.js
@@ -1,4 +1,5 @@
 const core = require("@actions/core");
+const os = require("os");
 const path = require("path");
 const process = require("process");
 const inputs = require("./inputs.js");
@@ -75,7 +76,7 @@ describe("stackCache", () => {
     it("stackCache.getPaths returns all artifact paths", async () => {
       await inExample(async () => {
         const cwd = process.cwd();
-        const home = process.env.HOME;
+        const home = os.homedir();
         const cachePaths = await stackCache.getPaths();
         expect(cachePaths).toStrictEqual([
           path.join(home, ".stack"),


### PR DESCRIPTION
* [Support projects who don't commit stack.yaml.lock](https://github.com/freckle/stack-cache-action/pull/103/commits/580b5368a11f400f35aed317578105c3d6fe7074)

  When not present, the `stack.yaml` itself will be used as the cache key.
This only matters in the edge-case of transitive dependencies through
the named resolver changing revisions or hashes without the resolver
name itself changing.

  It's unclear when that may happen, but if it does, a false-positive
cache hit is probably not problematic. Folks who care about correctness
to this degree, will be committing the `.lock` file for its
reproducibility guarantees anyway.

  Fixes https://github.com/freckle/stack-cache-action/issues/68.

* [Use platform-agnostic way to get $HOME](https://github.com/freckle/stack-cache-action/pull/103/commits/0fab10969a22c44b69e15df3640d8195e0b40101)

  https://stackoverflow.com/a/9081436

  Fixes https://github.com/freckle/stack-cache-action/issues/5.

* [Ensure ./.stack-work is always included](https://github.com/freckle/stack-cache-action/pull/103/commits/12d026e7abf85387159341f369d345647749da9b)

  Without this, we see partial caching in a multi-package project.

  The example in this project is a little un-realistic. It contains a
top-level package and a sub-directory package. Typically, there are only
sub-directory packages. For such cases, this action would've omitted
`./.stack-work` and not cached correctly. This fixes that and ensures it's
included for simple projects, top-and-sub projects (like example), and
sub-projects (as is common).

  It's unclear if we need to unique, but I'm doing so out of caution and
to at least prevent confusion when the values are logged.