### PR TITLE
Update to node16 runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "Stack cache"
 author: "freckle"
 description: "Caching Action for Stack-based Haskell projects"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
   post-if: "success()"


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/